### PR TITLE
get rid of bucket unlock since we no longer lock the bucket

### DIFF
--- a/pkg/hash/table.go
+++ b/pkg/hash/table.go
@@ -146,7 +146,7 @@ func (table *HashTable) Print(w io.Writer) {
 			continue
 		}
 		bucket.Print(w)
-		bucket.RUnlock()
+		// bucket.RUnlock()
 		bucket.page.Put()
 	}
 	io.WriteString(w, "====\n")
@@ -165,7 +165,7 @@ func (table *HashTable) PrintPN(pn int, w io.Writer) {
 		return
 	}
 	bucket.Print(w)
-	bucket.RUnlock()
+	// bucket.RUnlock()
 	bucket.page.Put()
 }
 


### PR DESCRIPTION
This was broken when  we changed `GetBucketAndLock` to `GetBucket` (thus we no longer need to unlock the bucket since it's not locked in the first place)